### PR TITLE
fix: remove valset hijacking detection

### DIFF
--- a/module/x/gravity/keeper/attestation_handler.go
+++ b/module/x/gravity/keeper/attestation_handler.go
@@ -302,9 +302,9 @@ func (a AttestationHandler) handleValsetUpdated(ctx sdk.Context, claim types.Msg
 		observedValset := claimSet
 		observedValset.Height = trustedValset.Height // overwrite the height, since it's not part of the claim
 
-		if _, err := trustedValset.Equal(observedValset); err != nil {
-			panic(fmt.Sprintf("Potential bridge highjacking: observed valset (%+v) does not match stored valset (%+v)! %s", observedValset, trustedValset, err.Error()))
-		}
+		//if _, err := trustedValset.Equal(observedValset); err != nil {
+		//	panic(fmt.Sprintf("Potential bridge highjacking: observed valset (%+v) does not match stored valset (%+v)! %s", observedValset, trustedValset, err.Error()))
+		//}
 
 		a.keeper.SetLastObservedValset(ctx, observedValset)
 	} else { // The 0th valset is not stored on chain init, but we need to set it as the last one
@@ -503,8 +503,8 @@ func (a AttestationHandler) sendCoinToCosmosAccount(
 // Send tokens via bank keeper to a native gravity address, re-prefixing receiver to a gravity native address if necessary
 // Note: This should only be used as part of SendToCosmos attestation handling and is not a good solution for general use
 func (a AttestationHandler) sendCoinToLocalAddress(
-	ctx sdk.Context, claim types.MsgSendToCosmosClaim, receiver sdk.AccAddress, coin sdk.Coin) (err error) {
-
+	ctx sdk.Context, claim types.MsgSendToCosmosClaim, receiver sdk.AccAddress, coin sdk.Coin,
+) (err error) {
 	err = a.keeper.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, receiver, sdk.NewCoins(coin))
 	if err != nil {
 		// someone attempted to send tokens to a blacklisted user from Ethereum, log and send to Community pool


### PR DESCRIPTION
This should fix the chain halt where we see consensus failures like: 

```
Potential bridge highjacking: observed valset ({Nonce:392 Members:[{Power:479919213 Et
hereumAddress:0x8af432eC6126E7b3C50F4dA3dFcD6b7C2Cd3b240} {Power:303499640 EthereumAddress:0xEEEEE5E7Fa69A5D258b1377b116b4A
0020cBcA1B} {Power:206852480 EthereumAddress:0x506b7259895E1Ce66983e0A08A757C909B7b4Ab4} {Power:206165339 EthereumAddress:0
```

The theory is that since gravity bridge is not updating the valset (tx are disabled). If there is a change in the validator set, gravity bridge will not update its state, but that will disagree with our actual validators.